### PR TITLE
Assign codeowners to tm-messenger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-messenger


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-messenger as codeowners.